### PR TITLE
Unpin python version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,10 +75,6 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: lts/*
-    - name: Setup Python # workaround for @electron/rebuild using node-gyp 9, which disagrees with python-3.12
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.11"
     - name: Prebuild
       run: |
         cd ./sonarview


### PR DESCRIPTION
No longer needed since @electron/rebuild is fixed